### PR TITLE
docs(layers-slices): update configuration example

### DIFF
--- a/src/rules/layers-slices/README.md
+++ b/src/rules/layers-slices/README.md
@@ -43,7 +43,7 @@ Example settings:
 
 ```json
 {
-  "conarti-fsd/layers-slices": ["error", {
+  "@conarti/feature-sliced/layers-slices": ["error", {
     "ignorePatterns": ["**/foo", "@/entities/bar"]
   }]
 }


### PR DESCRIPTION
Hi,
I was getting errors with the settings from the README.md:
`  1:1  error  Definition for rule 'conarti-fsd/layers-slices' was not found  conarti-fsd/layers-slices`

After a little bit of digging, I found the correct one.