### PR TITLE
feat(layers-slices): add allowSliceCrossImports option

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,8 @@ export interface LayerObjectConfig {
   name: string;
   /** Whether the layer can contain slices. Default: true */
   hasSlices?: boolean;
+  /** Whether to allow cross-imports between slices of this layer. Default: false */
+  allowSliceCrossImports?: boolean;
 }
 
 /**
@@ -83,6 +85,7 @@ export type LayersConfig = LayerConfigItem[];
 export interface NormalizedLayerConfig {
   name: string;
   hasSlices: boolean;
+  allowSliceCrossImports: boolean;
 }
 
 /**

--- a/src/lib/feature-sliced/index.ts
+++ b/src/lib/feature-sliced/index.ts
@@ -9,12 +9,12 @@ export {
   type PathsInfo,
 } from './extract-paths-info';
 export {
+  canLayerAllowSliceCrossImports,
+  canLayerContainSlices,
   getLayerWeight,
   isLayer,
 } from './layers';
 export {
-  canLayerAllowSliceCrossImports,
-  canLayerContainSlices,
   getLayerNames,
   getLayersWithoutSlices,
   getLayersWithSlices,

--- a/src/lib/feature-sliced/index.ts
+++ b/src/lib/feature-sliced/index.ts
@@ -13,6 +13,7 @@ export {
   isLayer,
 } from './layers';
 export {
+  canLayerAllowSliceCrossImports,
   canLayerContainSlices,
   getLayerNames,
   getLayersWithoutSlices,

--- a/src/lib/feature-sliced/layers-config.test.ts
+++ b/src/lib/feature-sliced/layers-config.test.ts
@@ -1,6 +1,7 @@
 import type { LayersConfig, NormalizedLayerConfig } from '../../config';
 import { DEFAULT_LAYERS_CONFIG } from '../../config';
 import {
+  canLayerAllowSliceCrossImports,
   canLayerContainSlices,
   getLayerNames,
   getLayersWithoutSlices,
@@ -15,8 +16,8 @@ describe('layers-config', () => {
     it('should return default config when no config provided', () => {
       const result = normalizeLayersConfig();
       expect(result).toHaveLength(7);
-      expect(result[0]).toEqual({ name: 'shared', hasSlices: false });
-      expect(result[6]).toEqual({ name: 'app', hasSlices: false });
+      expect(result[0]).toEqual({ name: 'shared', hasSlices: false, allowSliceCrossImports: false });
+      expect(result[6]).toEqual({ name: 'app', hasSlices: false, allowSliceCrossImports: false });
     });
 
     it('should normalize string items to objects with hasSlices: true', () => {
@@ -24,8 +25,8 @@ describe('layers-config', () => {
       const result = normalizeLayersConfig(config);
 
       expect(result).toEqual([
-        { name: 'entities', hasSlices: true },
-        { name: 'features', hasSlices: true },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'features', hasSlices: true, allowSliceCrossImports: false },
       ]);
     });
 
@@ -37,8 +38,8 @@ describe('layers-config', () => {
       const result = normalizeLayersConfig(config);
 
       expect(result).toEqual([
-        { name: 'shared', hasSlices: false },
-        { name: 'features', hasSlices: true },
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'features', hasSlices: true, allowSliceCrossImports: false },
       ]);
     });
 
@@ -46,7 +47,7 @@ describe('layers-config', () => {
       const config: LayersConfig = [{ name: 'entities' }];
       const result = normalizeLayersConfig(config);
 
-      expect(result).toEqual([{ name: 'entities', hasSlices: true }]);
+      expect(result).toEqual([{ name: 'entities', hasSlices: true, allowSliceCrossImports: false }]);
     });
 
     it('should convert layer names to lowercase', () => {
@@ -54,8 +55,8 @@ describe('layers-config', () => {
       const result = normalizeLayersConfig(config);
 
       expect(result).toEqual([
-        { name: 'entities', hasSlices: true },
-        { name: 'features', hasSlices: true },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'features', hasSlices: true, allowSliceCrossImports: false },
       ]);
     });
 
@@ -71,9 +72,9 @@ describe('layers-config', () => {
       const result = normalizeLayersConfig(config);
 
       expect(result).toHaveLength(6);
-      expect(result[0]).toEqual({ name: 'shared', hasSlices: false });
-      expect(result[1]).toEqual({ name: 'entities', hasSlices: true });
-      expect(result[5]).toEqual({ name: 'app', hasSlices: false });
+      expect(result[0]).toEqual({ name: 'shared', hasSlices: false, allowSliceCrossImports: false });
+      expect(result[1]).toEqual({ name: 'entities', hasSlices: true, allowSliceCrossImports: false });
+      expect(result[5]).toEqual({ name: 'app', hasSlices: false, allowSliceCrossImports: false });
     });
 
     it('should handle custom layers', () => {
@@ -86,10 +87,10 @@ describe('layers-config', () => {
       const result = normalizeLayersConfig(config);
 
       expect(result).toEqual([
-        { name: 'core', hasSlices: false },
-        { name: 'domain', hasSlices: true },
-        { name: 'application', hasSlices: true },
-        { name: 'infrastructure', hasSlices: false },
+        { name: 'core', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'domain', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'application', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'infrastructure', hasSlices: false, allowSliceCrossImports: false },
       ]);
     });
   });
@@ -97,8 +98,8 @@ describe('layers-config', () => {
   describe('getLayerNames', () => {
     it('should return array of layer names', () => {
       const config: NormalizedLayerConfig[] = [
-        { name: 'shared', hasSlices: false },
-        { name: 'entities', hasSlices: true },
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
       ];
 
       expect(getLayerNames(config)).toEqual(['shared', 'entities']);
@@ -112,10 +113,10 @@ describe('layers-config', () => {
   describe('getLayersWithSlices', () => {
     it('should return only layers with hasSlices: true', () => {
       const config: NormalizedLayerConfig[] = [
-        { name: 'shared', hasSlices: false },
-        { name: 'entities', hasSlices: true },
-        { name: 'features', hasSlices: true },
-        { name: 'app', hasSlices: false },
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'features', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'app', hasSlices: false, allowSliceCrossImports: false },
       ];
 
       expect(getLayersWithSlices(config)).toEqual(['entities', 'features']);
@@ -123,8 +124,8 @@ describe('layers-config', () => {
 
     it('should return empty array if no layers with slices', () => {
       const config: NormalizedLayerConfig[] = [
-        { name: 'shared', hasSlices: false },
-        { name: 'app', hasSlices: false },
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'app', hasSlices: false, allowSliceCrossImports: false },
       ];
 
       expect(getLayersWithSlices(config)).toEqual([]);
@@ -134,9 +135,9 @@ describe('layers-config', () => {
   describe('getLayersWithoutSlices', () => {
     it('should return only layers with hasSlices: false', () => {
       const config: NormalizedLayerConfig[] = [
-        { name: 'shared', hasSlices: false },
-        { name: 'entities', hasSlices: true },
-        { name: 'app', hasSlices: false },
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'app', hasSlices: false, allowSliceCrossImports: false },
       ];
 
       expect(getLayersWithoutSlices(config)).toEqual(['shared', 'app']);
@@ -144,8 +145,8 @@ describe('layers-config', () => {
 
     it('should return empty array if all layers have slices', () => {
       const config: NormalizedLayerConfig[] = [
-        { name: 'entities', hasSlices: true },
-        { name: 'features', hasSlices: true },
+        { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+        { name: 'features', hasSlices: true, allowSliceCrossImports: false },
       ];
 
       expect(getLayersWithoutSlices(config)).toEqual([]);
@@ -154,9 +155,9 @@ describe('layers-config', () => {
 
   describe('isKnownLayer', () => {
     const config: NormalizedLayerConfig[] = [
-      { name: 'shared', hasSlices: false },
-      { name: 'entities', hasSlices: true },
-      { name: 'features', hasSlices: true },
+      { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+      { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'features', hasSlices: true, allowSliceCrossImports: false },
     ];
 
     it('should return true for known layer', () => {
@@ -184,10 +185,10 @@ describe('layers-config', () => {
 
   describe('getLayerWeight', () => {
     const config: NormalizedLayerConfig[] = [
-      { name: 'shared', hasSlices: false },
-      { name: 'entities', hasSlices: true },
-      { name: 'features', hasSlices: true },
-      { name: 'app', hasSlices: false },
+      { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+      { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'features', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'app', hasSlices: false, allowSliceCrossImports: false },
     ];
 
     it('should return correct weight for each layer', () => {
@@ -215,10 +216,10 @@ describe('layers-config', () => {
 
   describe('canLayerContainSlices', () => {
     const config: NormalizedLayerConfig[] = [
-      { name: 'shared', hasSlices: false },
-      { name: 'entities', hasSlices: true },
-      { name: 'features', hasSlices: true },
-      { name: 'app', hasSlices: false },
+      { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+      { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'features', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'app', hasSlices: false, allowSliceCrossImports: false },
     ];
 
     it('should return true for layers with slices', () => {
@@ -238,6 +239,34 @@ describe('layers-config', () => {
 
     it('should return false for unknown layer', () => {
       expect(canLayerContainSlices('unknown', config)).toBe(false);
+    });
+  });
+
+  describe('canLayerAllowSliceCrossImports', () => {
+    const config: NormalizedLayerConfig[] = [
+      { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+      { name: 'modules', hasSlices: true, allowSliceCrossImports: true },
+      { name: 'features', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'app', hasSlices: false, allowSliceCrossImports: false },
+    ];
+
+    it('should return true for layers with allowSliceCrossImports: true', () => {
+      expect(canLayerAllowSliceCrossImports('modules', config)).toBe(true);
+    });
+
+    it('should return false for layers with allowSliceCrossImports: false', () => {
+      expect(canLayerAllowSliceCrossImports('shared', config)).toBe(false);
+      expect(canLayerAllowSliceCrossImports('features', config)).toBe(false);
+      expect(canLayerAllowSliceCrossImports('app', config)).toBe(false);
+    });
+
+    it('should handle case-insensitive lookup', () => {
+      expect(canLayerAllowSliceCrossImports('MODULES', config)).toBe(true);
+      expect(canLayerAllowSliceCrossImports('Modules', config)).toBe(true);
+    });
+
+    it('should return false for unknown layer', () => {
+      expect(canLayerAllowSliceCrossImports('unknown', config)).toBe(false);
     });
   });
 

--- a/src/lib/feature-sliced/layers-config.test.ts
+++ b/src/lib/feature-sliced/layers-config.test.ts
@@ -93,6 +93,19 @@ describe('layers-config', () => {
         { name: 'infrastructure', hasSlices: false, allowSliceCrossImports: false },
       ]);
     });
+
+    it('should ignore allowSliceCrossImports when hasSlices is false', () => {
+      const config: LayersConfig = [
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: true },
+        { name: 'modules', hasSlices: true, allowSliceCrossImports: true },
+      ];
+      const result = normalizeLayersConfig(config);
+
+      expect(result).toEqual([
+        { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+        { name: 'modules', hasSlices: true, allowSliceCrossImports: true },
+      ]);
+    });
   });
 
   describe('getLayerNames', () => {
@@ -270,7 +283,7 @@ describe('layers-config', () => {
     });
   });
 
-  describe('dEFAULT_LAYERS_CONFIG', () => {
+  describe('default layers config', () => {
     it('should have correct default FSD layers', () => {
       const normalized = normalizeLayersConfig(DEFAULT_LAYERS_CONFIG);
       const names = getLayerNames(normalized);

--- a/src/lib/feature-sliced/layers-config.ts
+++ b/src/lib/feature-sliced/layers-config.ts
@@ -13,12 +13,14 @@ function normalizeLayerConfigItem(item: LayerConfigItem): NormalizedLayerConfig 
     return {
       name: item.toLowerCase(),
       hasSlices: true,
+      allowSliceCrossImports: false,
     };
   }
 
   return {
     name: item.name.toLowerCase(),
     hasSlices: item.hasSlices ?? true,
+    allowSliceCrossImports: item.allowSliceCrossImports ?? false,
   };
 }
 
@@ -81,4 +83,13 @@ export function getLayerWeight(layer: string, config: NormalizedLayerConfig[]): 
 export function canLayerContainSlices(layer: string, config: NormalizedLayerConfig[]): boolean {
   const layerConfig = config.find((l) => l.name === layer.toLowerCase());
   return layerConfig?.hasSlices ?? false;
+}
+
+/**
+ * Checks if the layer allows cross-imports between its slices.
+ * Returns false if layer is not found.
+ */
+export function canLayerAllowSliceCrossImports(layer: string, config: NormalizedLayerConfig[]): boolean {
+  const layerConfig = config.find((l) => l.name === layer.toLowerCase());
+  return layerConfig?.allowSliceCrossImports ?? false;
 }

--- a/src/lib/feature-sliced/layers-config.ts
+++ b/src/lib/feature-sliced/layers-config.ts
@@ -6,7 +6,9 @@ import type {
 import { DEFAULT_LAYERS_CONFIG } from '../../config';
 
 /**
- * Normalizes a single layer config item to NormalizedLayerConfig
+ * Normalizes a single layer config item to NormalizedLayerConfig.
+ * Note: allowSliceCrossImports is ignored when hasSlices is false,
+ * since cross-slice imports are not possible without slices.
  */
 function normalizeLayerConfigItem(item: LayerConfigItem): NormalizedLayerConfig {
   if (typeof item === 'string') {
@@ -17,10 +19,12 @@ function normalizeLayerConfigItem(item: LayerConfigItem): NormalizedLayerConfig 
     };
   }
 
+  const hasSlices = item.hasSlices ?? true;
+
   return {
     name: item.name.toLowerCase(),
-    hasSlices: item.hasSlices ?? true,
-    allowSliceCrossImports: item.allowSliceCrossImports ?? false,
+    hasSlices,
+    allowSliceCrossImports: hasSlices ? (item.allowSliceCrossImports ?? false) : false,
   };
 }
 

--- a/src/lib/feature-sliced/layers.ts
+++ b/src/lib/feature-sliced/layers.ts
@@ -1,5 +1,6 @@
 import type { NormalizedLayerConfig } from '../../config';
 import {
+  canLayerAllowSliceCrossImports as canAllowSliceCrossImportsWithConfig,
   canLayerContainSlices as canContainSlicesWithConfig,
   getLayerWeight as getWeightWithConfig,
   isKnownLayer,
@@ -31,4 +32,13 @@ export function getLayerWeight(layer: string, config?: NormalizedLayerConfig[]):
 export function canLayerContainSlices(layer: string, config?: NormalizedLayerConfig[]): boolean {
   const layersConfig = config ?? normalizeLayersConfig();
   return canContainSlicesWithConfig(layer, layersConfig);
+}
+
+/**
+ * Checks if layer allows cross-imports between its slices.
+ * If config is not provided, uses default FSD layers.
+ */
+export function canLayerAllowSliceCrossImports(layer: string, config?: NormalizedLayerConfig[]): boolean {
+  const layersConfig = config ?? normalizeLayersConfig();
+  return canAllowSliceCrossImportsWithConfig(layer, layersConfig);
 }

--- a/src/lib/rule/extract-layers-config.test.ts
+++ b/src/lib/rule/extract-layers-config.test.ts
@@ -15,8 +15,8 @@ describe('extractLayersConfig', () => {
     const result = extractLayersConfig(context);
 
     expect(result).toHaveLength(7);
-    expect(result[0]).toEqual({ name: 'shared', hasSlices: false });
-    expect(result[6]).toEqual({ name: 'app', hasSlices: false });
+    expect(result[0]).toEqual({ name: 'shared', hasSlices: false, allowSliceCrossImports: false });
+    expect(result[6]).toEqual({ name: 'app', hasSlices: false, allowSliceCrossImports: false });
   });
 
   it('should return default config when plugin settings are empty', () => {
@@ -30,9 +30,9 @@ describe('extractLayersConfig', () => {
 
   it('should return custom layers from settings', () => {
     const customLayers: NormalizedLayerConfig[] = [
-      { name: 'shared', hasSlices: false },
-      { name: 'entities', hasSlices: true },
-      { name: 'app', hasSlices: false },
+      { name: 'shared', hasSlices: false, allowSliceCrossImports: false },
+      { name: 'entities', hasSlices: true, allowSliceCrossImports: false },
+      { name: 'app', hasSlices: false, allowSliceCrossImports: false },
     ];
 
     const context = createMockContext({

--- a/src/rules/layers-slices/index.custom-layers.test.ts
+++ b/src/rules/layers-slices/index.custom-layers.test.ts
@@ -202,3 +202,76 @@ ruleTester.run('layers-slices (extra layers)', rule, {
     },
   ],
 });
+
+/**
+ * Test allowSliceCrossImports option
+ * When enabled for a layer, cross-imports between slices of that layer are allowed.
+ */
+const layersWithCrossImports = [
+  { name: 'shared', hasSlices: false },
+  { name: 'modules', hasSlices: true, allowSliceCrossImports: true },
+  'features',
+  { name: 'app', hasSlices: false },
+];
+
+const crossImportsSettings = makeCustomLayersSettings(layersWithCrossImports);
+const crossImportsLayersOrder = 'shared -> modules -> features -> app';
+
+ruleTester.run('layers-slices (allowSliceCrossImports)', rule, {
+  valid: [
+    {
+      name: 'should allow cross-slice import when allowSliceCrossImports is true',
+      filename: 'src/modules/user/model.ts',
+      code: "import { Order } from '@/modules/order'",
+      settings: crossImportsSettings,
+    },
+    {
+      name: 'should allow cross-slice import with relative path',
+      filename: 'src/modules/user/ui/Card.tsx',
+      code: "import { orderModel } from '../../order/model'",
+      settings: crossImportsSettings,
+    },
+    {
+      name: 'should still allow same-slice import',
+      filename: 'src/modules/user/ui.ts',
+      code: "import { userModel } from '@/modules/user/model'",
+      settings: crossImportsSettings,
+    },
+    {
+      name: 'should still allow import from lower layer',
+      filename: 'src/modules/user/model.ts',
+      code: "import { api } from '@/shared/api'",
+      settings: crossImportsSettings,
+    },
+    {
+      name: 'should allow import from modules to features',
+      filename: 'src/features/auth/model.ts',
+      code: "import { User } from '@/modules/user'",
+      settings: crossImportsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should still error cross-slice in layer without allowSliceCrossImports',
+      filename: 'src/features/auth/model.ts',
+      code: "import { cart } from '@/features/cart'",
+      settings: crossImportsSettings,
+      errors: [makeCustomLayersSlicesError('features', 'features', crossImportsLayersOrder)],
+    },
+    {
+      name: 'should still error import from higher layer',
+      filename: 'src/modules/user/model.ts',
+      code: "import { AuthFeature } from '@/features/auth'",
+      settings: crossImportsSettings,
+      errors: [makeCustomLayersSlicesError('features', 'modules', crossImportsLayersOrder)],
+    },
+    {
+      name: 'should error when importing from modules layer to shared',
+      filename: 'src/shared/utils.ts',
+      code: "import { User } from '@/modules/user'",
+      settings: crossImportsSettings,
+      errors: [makeCustomLayersSlicesError('modules', 'shared', crossImportsLayersOrder)],
+    },
+  ],
+});

--- a/src/rules/layers-slices/model/validate-and-report.ts
+++ b/src/rules/layers-slices/model/validate-and-report.ts
@@ -10,14 +10,12 @@ import {
   type TSESTree,
 } from '@typescript-eslint/utils';
 import {
+  canLayerAllowSliceCrossImports,
   extractCrossImportInfo,
   extractPathsInfo,
+  normalizeLayersConfig,
   type PathsInfo,
 } from '../../../lib/feature-sliced';
-import {
-  canLayerAllowSliceCrossImports,
-  normalizeLayersConfig,
-} from '../../../lib/feature-sliced/layers-config';
 import {
   extractRuleOptions,
   hasPath,

--- a/src/rules/layers-slices/model/validate-and-report.ts
+++ b/src/rules/layers-slices/model/validate-and-report.ts
@@ -14,7 +14,10 @@ import {
   extractPathsInfo,
   type PathsInfo,
 } from '../../../lib/feature-sliced';
-import { normalizeLayersConfig } from '../../../lib/feature-sliced/layers-config';
+import {
+  canLayerAllowSliceCrossImports,
+  normalizeLayersConfig,
+} from '../../../lib/feature-sliced/layers-config';
 import {
   extractRuleOptions,
   hasPath,
@@ -101,12 +104,23 @@ export function validateAndReport(
     return;
   }
 
+  /*
+   * Check allowSliceCrossImports for same-layer cross-slice imports.
+   * If enabled for the target layer, allow imports between slices.
+   */
+  const layersConfig = config ?? normalizeLayersConfig();
+  if (pathsInfo.isSameLayer && !pathsInfo.isSameSlice) {
+    const targetLayer = pathsInfo.fsdPartsOfTarget.layer;
+    if (targetLayer && canLayerAllowSliceCrossImports(targetLayer, layersConfig)) {
+      return;
+    }
+  }
+
   if (isNotSuitableForValidation(pathsInfo)) {
     return;
   }
 
   const { allowTypeImports } = extractRuleOptions(optionsWithDefault);
-  const layersConfig = config ?? normalizeLayersConfig();
   const nodesToReport = validate(node, pathsInfo, allowTypeImports, layersConfig);
   reportValidationErrors(nodesToReport, context, pathsInfo, layersConfig);
 }


### PR DESCRIPTION
## Summary
- Add per-layer `allowSliceCrossImports` option to allow cross-imports between slices
- Enables architectures where modules (Bounded Contexts) can import from each other through Public API

## Example
```js
settings: {
  '@conarti/feature-sliced': {
    layers: [
      { name: 'shared', hasSlices: false },
      { name: 'modules', hasSlices: true, allowSliceCrossImports: true },
      { name: 'app', hasSlices: false },
    ],
  },
}
```

## Test plan
- [x] Unit tests for `canLayerAllowSliceCrossImports` function
- [x] Integration tests for layers-slices rule with new option
- [x] All 407 tests passing
- [x] Type-check passing
- [x] Lint passing

Closes #21