### PR TITLE
feat: add custom segments configuration (Issue #22)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -631,7 +631,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -111,6 +111,7 @@ export type Segment = Segments[number];
 
 /**
  * Slice segments regulated by feature-sliced methodologies
+ * @deprecated Use normalizeSegmentsConfig() from segments-config.ts for custom segments support
  */
 export const segments: Segments = [
   'ui',
@@ -120,6 +121,25 @@ export const segments: Segments = [
   'config',
   'assets',
 ];
+
+/**
+ * Default FSD segments
+ */
+export const DEFAULT_SEGMENTS: readonly string[] = [
+  'ui',
+  'model',
+  'lib',
+  'api',
+  'config',
+  'assets',
+];
+
+/* === Segment Customization Types === */
+
+/**
+ * Segments configuration: array extends defaults, object with replace replaces them
+ */
+export type SegmentsConfig = string[] | { replace: string[] };
 
 export const pathSeparator = '/';
 

--- a/src/lib/feature-sliced/extract-feature-sliced-parts.ts
+++ b/src/lib/feature-sliced/extract-feature-sliced-parts.ts
@@ -3,18 +3,26 @@ import { extractLayer } from './extract-layer';
 import { extractSegment } from './extract-segment';
 import { extractSlice } from './extract-slice';
 
+interface ExtractOptions {
+  layersConfig?: NormalizedLayerConfig[];
+  segmentsConfig?: string[];
+}
+
 /**
  * Extracts all FSD parts from a path.
- * If config is not provided, uses default FSD layers.
+ * If layersConfig is not provided, uses default FSD layers.
+ * If segmentsConfig is not provided, uses default FSD segments.
  */
 export function extractFeatureSlicedParts(
   targetPath: string,
   cwd?: string,
-  config?: NormalizedLayerConfig[],
+  options?: ExtractOptions,
 ) {
-  const layer = extractLayer(targetPath, cwd, config);
-  const slice = extractSlice(targetPath, config);
-  const [segment, segmentFiles] = extractSegment(targetPath, config);
+  const { layersConfig, segmentsConfig } = options ?? {};
+
+  const layer = extractLayer(targetPath, cwd, layersConfig);
+  const slice = extractSlice(targetPath, layersConfig, segmentsConfig);
+  const [segment, segmentFiles] = extractSegment(targetPath, layersConfig, segmentsConfig);
 
   return {
     layer,

--- a/src/lib/feature-sliced/extract-paths-info.ts
+++ b/src/lib/feature-sliced/extract-paths-info.ts
@@ -54,15 +54,23 @@ function compareFeatureSlicedParts(fsPartsToCompare: FSPartsToCompare) {
   };
 }
 
+interface ExtractPathsInfoOptions {
+  layersConfig?: NormalizedLayerConfig[];
+  segmentsConfig?: string[];
+}
+
 /**
  * Extracts paths info including FSD parts.
- * If config is not provided, uses default FSD layers.
+ * If layersConfig is not provided, uses default FSD layers.
+ * If segmentsConfig is not provided, uses default FSD segments.
  */
 export function extractPathsInfo(
   node: ImportExportNodesWithSourceValue,
   context: UnknownRuleContext,
-  config?: NormalizedLayerConfig[],
+  options?: ExtractPathsInfoOptions,
 ) {
+  const { layersConfig, segmentsConfig } = options ?? {};
+
   const {
     targetPath,
     normalizedTargetPath,
@@ -71,11 +79,11 @@ export function extractPathsInfo(
     normalizedCwd,
   } = extractPaths(node, context);
 
-  const fsdPartsOfTarget = extractFeatureSlicedParts(absoluteTargetPath, normalizedCwd, config);
-  const fsdPartsOfCurrentFile = extractFeatureSlicedParts(normalizedCurrentFilePath, normalizedCwd, config);
+  const fsdPartsOfTarget = extractFeatureSlicedParts(absoluteTargetPath, normalizedCwd, { layersConfig, segmentsConfig });
+  const fsdPartsOfCurrentFile = extractFeatureSlicedParts(normalizedCurrentFilePath, normalizedCwd, { layersConfig, segmentsConfig });
 
-  const validatedFeatureSlicedPartsOfTarget = validateExtractedFeatureSlicedParts(fsdPartsOfTarget, config);
-  const validatedFeatureSlicedPartsOfCurrentFile = validateExtractedFeatureSlicedParts(fsdPartsOfCurrentFile, config);
+  const validatedFeatureSlicedPartsOfTarget = validateExtractedFeatureSlicedParts(fsdPartsOfTarget, layersConfig);
+  const validatedFeatureSlicedPartsOfCurrentFile = validateExtractedFeatureSlicedParts(fsdPartsOfCurrentFile, layersConfig);
 
   const {
     hasUnknownLayers,

--- a/src/lib/feature-sliced/extract-segment.test.ts
+++ b/src/lib/feature-sliced/extract-segment.test.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_SEGMENTS,
   layersWithoutSlices,
   segments,
 } from '../../config';
@@ -6,6 +7,7 @@ import { extractSegment } from './extract-segment';
 
 const FSD_SEGMENTS = segments;
 const FSD_LAYERS_WITHOUT_SLICES = layersWithoutSlices;
+const CUSTOM_SEGMENTS = [...DEFAULT_SEGMENTS, 'services', 'hooks'];
 
 describe('extract-segment', () => {
   interface TestCase {
@@ -107,5 +109,81 @@ describe('extract-segment', () => {
   }) => {
     const actual = extractSegment(path);
     expect(actual).toStrictEqual(expected);
+  });
+
+  describe('with custom segments config', () => {
+    it('should recognize custom segment when provided in config', () => {
+      const result = extractSegment(
+        'src/entities/foo/services/index.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual(['services', 'index.ts']);
+    });
+
+    it('should recognize another custom segment', () => {
+      const result = extractSegment(
+        'src/features/bar/hooks/useAuth.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual(['hooks', 'useAuth.ts']);
+    });
+
+    it('should still recognize default segments with custom config', () => {
+      const result = extractSegment(
+        'src/entities/foo/ui/Button.tsx',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual(['ui', 'Button.tsx']);
+    });
+
+    it('should not recognize unknown segment even with custom config', () => {
+      const result = extractSegment(
+        'src/entities/foo/unknown/index.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual([null, null]);
+    });
+
+    it('should work with replace mode (only custom segments)', () => {
+      const replaceSegments = ['services', 'stores'];
+      const result = extractSegment(
+        'src/entities/foo/services/index.ts',
+        undefined,
+        replaceSegments,
+      );
+      expect(result).toStrictEqual(['services', 'index.ts']);
+    });
+
+    it('should not recognize default segment in replace mode if not included', () => {
+      const replaceSegments = ['services', 'stores'];
+      const result = extractSegment(
+        'src/entities/foo/ui/Button.tsx',
+        undefined,
+        replaceSegments,
+      );
+      expect(result).toStrictEqual([null, null]);
+    });
+
+    it('should work with custom segments as folder', () => {
+      const result = extractSegment(
+        'src/features/auth/services',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual(['services', null]);
+    });
+
+    it('should work with custom segments as file', () => {
+      const result = extractSegment(
+        'src/features/auth/services.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toStrictEqual(['services', null]);
+    });
   });
 });

--- a/src/lib/feature-sliced/extract-segment.ts
+++ b/src/lib/feature-sliced/extract-segment.ts
@@ -1,5 +1,5 @@
-import type { NormalizedLayerConfig, Segment } from '../../config';
-import { segments } from '../../config';
+import type { NormalizedLayerConfig } from '../../config';
+import { DEFAULT_SEGMENTS } from '../../config';
 import {
   getLayersWithSlices,
   normalizeLayersConfig,
@@ -7,9 +7,9 @@ import {
 
 type SegmentFiles = string | null;
 
-function createFsdPartsRegExp(layersWithSlices: string[]): RegExp {
+function createFsdPartsRegExp(layersWithSlices: string[], segmentsList: string[]): RegExp {
   const layersUnion = layersWithSlices.join('|');
-  const segmentsUnion = segments.join('|');
+  const segmentsUnion = segmentsList.join('|');
   return new RegExp(
     `(?<=(?<layer>${layersUnion}))\\/(?<slice>([\\w-]*\\/)+?)(?<segment>(${segmentsUnion})(\\.\\w+)?)(\\/(?<segmentFiles>.*))?`,
   );
@@ -17,15 +17,18 @@ function createFsdPartsRegExp(layersWithSlices: string[]): RegExp {
 
 /**
  * Extracts segment from the path.
- * If config is not provided, uses default FSD layers.
+ * If layersConfig is not provided, uses default FSD layers.
+ * If segmentsConfig is not provided, uses default FSD segments.
  */
 export function extractSegment(
   targetPath: string,
-  config?: NormalizedLayerConfig[],
-): [Segment | null, SegmentFiles] {
-  const layersConfig = config ?? normalizeLayersConfig();
-  const layersWithSlices = getLayersWithSlices(layersConfig);
-  const fsdPartsRegExp = createFsdPartsRegExp(layersWithSlices);
+  layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
+): [string | null, SegmentFiles] {
+  const normalizedLayersConfig = layersConfig ?? normalizeLayersConfig();
+  const segmentsList = segmentsConfig ?? [...DEFAULT_SEGMENTS];
+  const layersWithSlices = getLayersWithSlices(normalizedLayersConfig);
+  const fsdPartsRegExp = createFsdPartsRegExp(layersWithSlices, segmentsList);
 
   const fsdParts = targetPath.match(fsdPartsRegExp);
 
@@ -41,5 +44,5 @@ export function extractSegment(
   const fileExtensionRegExp = /\.[^/.]+$/;
   const segmentWithoutFileExtension = segment?.replace(fileExtensionRegExp, '') || null;
 
-  return [segmentWithoutFileExtension as Segment | null, segmentFiles];
+  return [segmentWithoutFileExtension, segmentFiles];
 }

--- a/src/lib/feature-sliced/extract-slice.test.ts
+++ b/src/lib/feature-sliced/extract-slice.test.ts
@@ -1,7 +1,8 @@
-import { layersWithoutSlices } from '../../config';
+import { DEFAULT_SEGMENTS, layersWithoutSlices } from '../../config';
 import { extractSlice } from './extract-slice';
 
 const FSD_LAYERS_WITHOUT_SLICES = layersWithoutSlices;
+const CUSTOM_SEGMENTS = [...DEFAULT_SEGMENTS, 'services', 'hooks'];
 
 describe('extract-slice', () => {
   describe('layers without slices', () => {
@@ -184,6 +185,65 @@ describe('extract-slice', () => {
 
     it.each(cases)('$name: $path', ({ path, expected }) => {
       expect(extractSlice(path)).toBe(expected);
+    });
+  });
+
+  describe('with custom segments config', () => {
+    it('should use custom segment as boundary for slice detection', () => {
+      const result = extractSlice(
+        'src/entities/foo/services/index.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toBe('foo');
+    });
+
+    it('should work with another custom segment', () => {
+      const result = extractSlice(
+        'src/features/auth/LoginForm/hooks/useAuth.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toBe('LoginForm');
+    });
+
+    it('should still recognize default segments with custom config', () => {
+      const result = extractSlice(
+        'src/entities/User/model/index.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toBe('User');
+    });
+
+    it('should use fallback when unknown segment used (not in custom config)', () => {
+      const replaceSegments = ['services', 'stores'];
+      const result = extractSlice(
+        'src/entities/foo/ui/index.ts',
+        undefined,
+        replaceSegments,
+      );
+      /* When ui is not recognized as segment, fallback returns last folder */
+      expect(result).toBe('ui');
+    });
+
+    it('should work with replace mode segments', () => {
+      const replaceSegments = ['services', 'stores'];
+      const result = extractSlice(
+        'src/entities/foo/services/index.ts',
+        undefined,
+        replaceSegments,
+      );
+      expect(result).toBe('foo');
+    });
+
+    it('should work with group folders and custom segments', () => {
+      const result = extractSlice(
+        'src/entities/group/User/services/api.ts',
+        undefined,
+        CUSTOM_SEGMENTS,
+      );
+      expect(result).toBe('User');
     });
   });
 });

--- a/src/lib/feature-sliced/extract-slice.ts
+++ b/src/lib/feature-sliced/extract-slice.ts
@@ -1,5 +1,5 @@
 import type { NormalizedLayerConfig } from '../../config';
-import { segments } from '../../config';
+import { DEFAULT_SEGMENTS } from '../../config';
 import {
   getLayersWithSlices,
   normalizeLayersConfig,
@@ -9,11 +9,12 @@ import {
  * Extracts slice from the path.
  *
  * Heuristic: slice is the last path segment BEFORE an FSD-segment
- * (ui/model/lib/api/config/assets) or file.
+ * (ui/model/lib/api/config/assets or custom segments) or file.
  *
  * Fallback: if no FSD-segment found, take the last segment after layer.
  *
- * If config is not provided, uses default FSD layers.
+ * If layersConfig is not provided, uses default FSD layers.
+ * If segmentsConfig is not provided, uses default FSD segments.
  *
  * @example
  * 'entities/User/model' -> 'User'
@@ -22,10 +23,12 @@ import {
  */
 export function extractSlice(
   targetPath: string,
-  config?: NormalizedLayerConfig[],
+  layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
 ): string | null {
-  const layersConfig = config ?? normalizeLayersConfig();
-  const layersWithSlices = getLayersWithSlices(layersConfig);
+  const normalizedLayersConfig = layersConfig ?? normalizeLayersConfig();
+  const segmentsList = segmentsConfig ?? [...DEFAULT_SEGMENTS];
+  const layersWithSlices = getLayersWithSlices(normalizedLayersConfig);
 
   /* Remove filename (e.g., /index.ts or /model.ts) */
   const pathWithoutFile = targetPath.replace(/\/[\w-]+\.\w+$/, '');
@@ -48,7 +51,7 @@ export function extractSlice(
 
   /* Find index of first FSD-segment (case-insensitive) */
   const segmentIndex = partsAfterLayer.findIndex((part) =>
-    segments.some((seg) => seg.toLowerCase() === part.toLowerCase()),
+    segmentsList.some((seg) => seg.toLowerCase() === part.toLowerCase()),
   );
 
   /* If FSD-segment found and there's at least one element before it */

--- a/src/lib/feature-sliced/segments-config.test.ts
+++ b/src/lib/feature-sliced/segments-config.test.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_SEGMENTS } from '../../config';
 import {
-  getSegmentNames,
   isKnownSegment,
   normalizeSegmentsConfig,
 } from './segments-config';
@@ -68,18 +67,6 @@ describe('segments-config', () => {
       const result = normalizeSegmentsConfig({ replace: ['ui', 'UI', 'model'] });
 
       expect(result).toEqual(['ui', 'model']);
-    });
-  });
-
-  describe('getSegmentNames', () => {
-    it('should return segment names from array', () => {
-      const segments = ['ui', 'model', 'services'];
-
-      expect(getSegmentNames(segments)).toEqual(['ui', 'model', 'services']);
-    });
-
-    it('should return empty array for empty config', () => {
-      expect(getSegmentNames([])).toEqual([]);
     });
   });
 

--- a/src/lib/feature-sliced/segments-config.test.ts
+++ b/src/lib/feature-sliced/segments-config.test.ts
@@ -1,0 +1,130 @@
+import { DEFAULT_SEGMENTS } from '../../config';
+import {
+  getSegmentNames,
+  isKnownSegment,
+  normalizeSegmentsConfig,
+} from './segments-config';
+
+describe('segments-config', () => {
+  describe('normalizeSegmentsConfig', () => {
+    it('should return default segments when no config provided', () => {
+      const result = normalizeSegmentsConfig();
+
+      expect(result).toEqual(DEFAULT_SEGMENTS);
+    });
+
+    it('should return default segments when config is undefined', () => {
+      const result = normalizeSegmentsConfig(undefined);
+
+      expect(result).toEqual(DEFAULT_SEGMENTS);
+    });
+
+    it('should extend defaults when array provided (extend mode)', () => {
+      const result = normalizeSegmentsConfig(['services', 'hooks']);
+
+      expect(result).toEqual([...DEFAULT_SEGMENTS, 'services', 'hooks']);
+    });
+
+    it('should replace defaults when object with replace provided', () => {
+      const result = normalizeSegmentsConfig({ replace: ['ui', 'services'] });
+
+      expect(result).toEqual(['ui', 'services']);
+    });
+
+    it('should convert segment names to lowercase in extend mode', () => {
+      const result = normalizeSegmentsConfig(['Services', 'HOOKS']);
+
+      expect(result).toContain('services');
+      expect(result).toContain('hooks');
+    });
+
+    it('should convert segment names to lowercase in replace mode', () => {
+      const result = normalizeSegmentsConfig({ replace: ['UI', 'Model'] });
+
+      expect(result).toEqual(['ui', 'model']);
+    });
+
+    it('should handle empty array in extend mode', () => {
+      const result = normalizeSegmentsConfig([]);
+
+      expect(result).toEqual(DEFAULT_SEGMENTS);
+    });
+
+    it('should handle empty array in replace mode', () => {
+      const result = normalizeSegmentsConfig({ replace: [] });
+
+      expect(result).toEqual([]);
+    });
+
+    it('should remove duplicates in extend mode', () => {
+      const result = normalizeSegmentsConfig(['ui', 'services', 'UI']);
+
+      const uiCount = result.filter((s) => s === 'ui').length;
+      expect(uiCount).toBe(1);
+      expect(result).toContain('services');
+    });
+
+    it('should remove duplicates in replace mode', () => {
+      const result = normalizeSegmentsConfig({ replace: ['ui', 'UI', 'model'] });
+
+      expect(result).toEqual(['ui', 'model']);
+    });
+  });
+
+  describe('getSegmentNames', () => {
+    it('should return segment names from array', () => {
+      const segments = ['ui', 'model', 'services'];
+
+      expect(getSegmentNames(segments)).toEqual(['ui', 'model', 'services']);
+    });
+
+    it('should return empty array for empty config', () => {
+      expect(getSegmentNames([])).toEqual([]);
+    });
+  });
+
+  describe('isKnownSegment', () => {
+    const segments = ['ui', 'model', 'services'];
+
+    it('should return true for known segment', () => {
+      expect(isKnownSegment('ui', segments)).toBe(true);
+      expect(isKnownSegment('services', segments)).toBe(true);
+    });
+
+    it('should return true for known segment with different case', () => {
+      expect(isKnownSegment('UI', segments)).toBe(true);
+      expect(isKnownSegment('Model', segments)).toBe(true);
+    });
+
+    it('should return false for unknown segment', () => {
+      expect(isKnownSegment('unknown', segments)).toBe(false);
+      expect(isKnownSegment('api', segments)).toBe(false);
+    });
+
+    it('should return false for non-string values', () => {
+      expect(isKnownSegment(null, segments)).toBe(false);
+      expect(isKnownSegment(undefined, segments)).toBe(false);
+      expect(isKnownSegment(123, segments)).toBe(false);
+      expect(isKnownSegment({ name: 'ui' }, segments)).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(isKnownSegment('', segments)).toBe(false);
+    });
+  });
+
+  describe('default segments constant', () => {
+    it('should contain all FSD default segments', () => {
+      expect(DEFAULT_SEGMENTS).toContain('ui');
+      expect(DEFAULT_SEGMENTS).toContain('model');
+      expect(DEFAULT_SEGMENTS).toContain('lib');
+      expect(DEFAULT_SEGMENTS).toContain('api');
+      expect(DEFAULT_SEGMENTS).toContain('config');
+      expect(DEFAULT_SEGMENTS).toContain('assets');
+    });
+
+    it('should have exactly 6 default segments', () => {
+      expect(DEFAULT_SEGMENTS).toHaveLength(6);
+    });
+  });
+});

--- a/src/lib/feature-sliced/segments-config.ts
+++ b/src/lib/feature-sliced/segments-config.ts
@@ -23,13 +23,6 @@ export function normalizeSegmentsConfig(config?: SegmentsConfig): string[] {
 }
 
 /**
- * Returns segment names from normalized config
- */
-export function getSegmentNames(segments: string[]): string[] {
-  return segments;
-}
-
-/**
  * Checks if the given string is a known segment
  */
 export function isKnownSegment(segment: unknown, segments: string[]): boolean {

--- a/src/lib/feature-sliced/segments-config.ts
+++ b/src/lib/feature-sliced/segments-config.ts
@@ -1,0 +1,41 @@
+import type { SegmentsConfig } from '../../config';
+import { DEFAULT_SEGMENTS } from '../../config';
+
+/**
+ * Normalizes segments configuration.
+ * - If no config provided, returns DEFAULT_SEGMENTS
+ * - If array provided (extend mode), adds custom segments to defaults
+ * - If object with replace provided, uses only specified segments
+ */
+export function normalizeSegmentsConfig(config?: SegmentsConfig): string[] {
+  if (!config) {
+    return [...DEFAULT_SEGMENTS];
+  }
+
+  if (Array.isArray(config)) {
+    const customSegments = config.map((s) => s.toLowerCase());
+    const combined = [...DEFAULT_SEGMENTS, ...customSegments];
+    return [...new Set(combined)];
+  }
+
+  const replacedSegments = config.replace.map((s) => s.toLowerCase());
+  return [...new Set(replacedSegments)];
+}
+
+/**
+ * Returns segment names from normalized config
+ */
+export function getSegmentNames(segments: string[]): string[] {
+  return segments;
+}
+
+/**
+ * Checks if the given string is a known segment
+ */
+export function isKnownSegment(segment: unknown, segments: string[]): boolean {
+  if (typeof segment !== 'string' || segment === '') {
+    return false;
+  }
+
+  return segments.includes(segment.toLowerCase());
+}

--- a/src/lib/rule/extract-segments-config.test.ts
+++ b/src/lib/rule/extract-segments-config.test.ts
@@ -1,0 +1,121 @@
+import type { UnknownRuleContext } from './models';
+import { DEFAULT_SEGMENTS, PLUGIN_NAME } from '../../config';
+import { extractSegmentsConfig } from './extract-segments-config';
+
+function createMockContext(settings?: Record<string, unknown>): UnknownRuleContext {
+  return {
+    settings: settings ?? {},
+  } as unknown as UnknownRuleContext;
+}
+
+describe('extractSegmentsConfig', () => {
+  it('should return default segments when no settings provided', () => {
+    const context = createMockContext();
+    const result = extractSegmentsConfig(context);
+
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should return default segments when plugin settings are empty', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {},
+    });
+    const result = extractSegmentsConfig(context);
+
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should extend defaults when array provided (extend mode)', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: ['services', 'hooks'],
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual([...DEFAULT_SEGMENTS, 'services', 'hooks']);
+  });
+
+  it('should replace defaults when object with replace provided', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: { replace: ['ui', 'services'] },
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual(['ui', 'services']);
+  });
+
+  it('should return default segments when segments is invalid type', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: 'not-valid',
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should return default segments when settings is undefined', () => {
+    const context = { settings: undefined } as unknown as UnknownRuleContext;
+    const result = extractSegmentsConfig(context);
+
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should handle settings without plugin key', () => {
+    const context = createMockContext({
+      someOtherPlugin: { foo: 'bar' },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should convert segment names to lowercase', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: ['Services', 'HOOKS'],
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toContain('services');
+    expect(result).toContain('hooks');
+  });
+
+  it('should handle object replace with lowercase conversion', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: { replace: ['UI', 'Model'] },
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual(['ui', 'model']);
+  });
+
+  it('should handle empty array in extend mode', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: [],
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual([...DEFAULT_SEGMENTS]);
+  });
+
+  it('should handle empty array in replace mode', () => {
+    const context = createMockContext({
+      [PLUGIN_NAME]: {
+        segments: { replace: [] },
+      },
+    });
+
+    const result = extractSegmentsConfig(context);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/lib/rule/extract-segments-config.ts
+++ b/src/lib/rule/extract-segments-config.ts
@@ -1,0 +1,36 @@
+import type { SegmentsConfig } from '../../config';
+import type { UnknownRuleContext } from './models';
+import { PLUGIN_NAME } from '../../config';
+import { normalizeSegmentsConfig } from '../feature-sliced/segments-config';
+
+interface PluginSettings {
+  segments?: SegmentsConfig;
+}
+
+function isValidSegmentsConfig(value: unknown): value is SegmentsConfig {
+  if (Array.isArray(value)) {
+    return value.every((item) => typeof item === 'string');
+  }
+
+  if (typeof value === 'object' && value !== null && 'replace' in value) {
+    const replaceValue = (value as { replace: unknown }).replace;
+    return Array.isArray(replaceValue) && replaceValue.every((item) => typeof item === 'string');
+  }
+
+  return false;
+}
+
+/**
+ * Extracts segments configuration from context.settings.
+ * If no config is provided in settings, returns normalized default config.
+ */
+export function extractSegmentsConfig(context: UnknownRuleContext): string[] {
+  const settings = context.settings as Record<string, unknown> | undefined;
+  const pluginSettings = settings?.[PLUGIN_NAME] as PluginSettings | undefined;
+
+  if (pluginSettings?.segments && isValidSegmentsConfig(pluginSettings.segments)) {
+    return normalizeSegmentsConfig(pluginSettings.segments);
+  }
+
+  return normalizeSegmentsConfig();
+}

--- a/src/lib/rule/index.ts
+++ b/src/lib/rule/index.ts
@@ -5,6 +5,7 @@ export { extractLayersConfig } from './extract-layers-config';
 export { extractNodePath } from './extract-node-path';
 export { extractPaths } from './extract-paths';
 export { extractRuleOptions } from './extract-rule-options';
+export { extractSegmentsConfig } from './extract-segments-config';
 export { getSourceRangeWithoutQuotes } from './get-source-range-without-quotes';
 export { hasPath } from './has-path';
 export { isIgnored } from './is-ignored';

--- a/src/rules/absolute-relative/model/validate-and-report.ts
+++ b/src/rules/absolute-relative/model/validate-and-report.ts
@@ -37,7 +37,7 @@ export function validateAndReport(
     return;
   }
 
-  const pathsInfo = extractPathsInfo(node, context, layersConfig);
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig });
 
   if (shouldBeRelative(pathsInfo)) {
     reportShouldBeRelative(node, context);

--- a/src/rules/layers-slices/index.custom-segments.test.ts
+++ b/src/rules/layers-slices/index.custom-segments.test.ts
@@ -1,0 +1,151 @@
+import * as tseslintParser from '@typescript-eslint/parser';
+import { RuleTester } from '../../../tests/rule-tester';
+import {
+  makeCustomLayersAndSegmentsSettings,
+  makeCustomLayersSlicesError,
+  makeCustomSegmentsSettings,
+  makeLayersSlicesError,
+} from '../../../tests/utils';
+import rule from './index';
+
+/**
+ * Custom segments configuration for testing (extend mode).
+ * Adds 'i18n', 'hooks', 'services' to default segments.
+ */
+const customSegments = ['i18n', 'hooks', 'services'];
+
+const customSegmentsSettings = makeCustomSegmentsSettings(customSegments);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    parser: tseslintParser,
+  },
+});
+
+ruleTester.run('layers-slices (custom segments - extend mode)', rule, {
+  valid: [
+    {
+      name: 'should allow import from same slice with custom segment (i18n -> model)',
+      filename: 'src/entities/foo/i18n/index.ts',
+      code: "import { fooModel } from '../model'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow import from lower layer when custom segment is used',
+      filename: 'src/features/bar/hooks/useAuth.ts',
+      code: "import { User } from '@/entities/user'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow same-slice relative import from model to custom i18n segment',
+      filename: 'src/entities/policies/model/actions.ts',
+      code: "import { t } from '../i18n'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow standard import with custom segments config',
+      filename: 'src/features/bar/ui.tsx',
+      code: "import { utils } from '@/shared/lib'",
+      settings: customSegmentsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on standard layer violation with custom segments',
+      filename: 'src/entities/bar/services/api.ts',
+      code: "import { AuthForm } from '@/features/auth'",
+      settings: customSegmentsSettings,
+      errors: [makeLayersSlicesError('features', 'entities')],
+    },
+    {
+      name: 'should error on cross-entity import with custom segments',
+      filename: 'src/entities/user/model.ts',
+      code: "import { Order } from '@/entities/order'",
+      settings: customSegmentsSettings,
+      errors: [makeLayersSlicesError('entities', 'entities')],
+    },
+  ],
+});
+
+ruleTester.run('layers-slices (custom segments - same slice relative imports)', rule, {
+  valid: [
+    {
+      name: 'should allow entities/policies/model importing ../i18n with custom segment',
+      filename: 'src/entities/policies/model/confirm-mass.ts',
+      code: "import { t } from '../i18n'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow entities/schedule/model importing ../i18n with custom segment',
+      filename: 'src/entities/schedule/model/actions.ts',
+      code: "import { translations } from '../i18n'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow entities/groups/model importing ../i18n with custom segment',
+      filename: 'src/entities/groups/model/groups-node-actions.ts',
+      code: "import { labels } from '../i18n'",
+      settings: customSegmentsSettings,
+    },
+    {
+      name: 'should allow import from custom segment subfolder within same slice',
+      filename: 'src/entities/user/services/api.ts',
+      code: "import { UserType } from '../model/types'",
+      settings: customSegmentsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on cross-entity import through custom segment path',
+      filename: 'src/entities/user/i18n/index.ts',
+      code: "import { Order } from '@/entities/order'",
+      settings: customSegmentsSettings,
+      errors: [makeLayersSlicesError('entities', 'entities')],
+    },
+  ],
+});
+
+/**
+ * Test with both custom layers and custom segments combined
+ */
+const customLayers = [
+  { name: 'core', hasSlices: false },
+  'domain',
+  'features',
+  'pages',
+  { name: 'app', hasSlices: false },
+];
+
+const combinedSettings = makeCustomLayersAndSegmentsSettings(customLayers, customSegments);
+const customLayersOrder = 'core -> domain -> features -> pages -> app';
+
+ruleTester.run('layers-slices (custom segments + custom layers combined)', rule, {
+  valid: [
+    {
+      name: 'should allow custom layer + custom segment (core -> domain)',
+      filename: 'src/domain/user/services/api.ts',
+      code: "import { config } from '@/core/utils'",
+      settings: combinedSettings,
+    },
+    {
+      name: 'should allow same slice relative import with custom segment in custom layer',
+      filename: 'src/domain/user/hooks/useUser.ts',
+      code: "import { userModel } from '../model'",
+      settings: combinedSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on layer violation with custom segments and custom layers',
+      filename: 'src/core/utils.ts',
+      code: "import { AuthForm } from '@/features/auth'",
+      settings: combinedSettings,
+      errors: [makeCustomLayersSlicesError('features', 'core', customLayersOrder)],
+    },
+  ],
+});

--- a/src/rules/layers-slices/index.ts
+++ b/src/rules/layers-slices/index.ts
@@ -5,6 +5,7 @@ import type {
 import {
   createEslintRule,
   extractLayersConfig,
+  extractSegmentsConfig,
   type ImportExpression,
 } from '../../lib/rule';
 import { ERROR_MESSAGE_ID } from './config';
@@ -54,13 +55,14 @@ export default createEslintRule<Options, MessageIds>({
 
   create(context, optionsWithDefault) {
     const layersConfig = extractLayersConfig(context);
+    const segmentsConfig = extractSegmentsConfig(context);
 
     return {
       ImportDeclaration(node) {
-        validateAndReport(node, context, optionsWithDefault, layersConfig);
+        validateAndReport(node, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
       ImportExpression(node) {
-        validateAndReport(node as ImportExpression /* TSESTree has invalid type for this node */, context, optionsWithDefault, layersConfig);
+        validateAndReport(node as ImportExpression /* TSESTree has invalid type for this node */, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
     };
   },

--- a/src/rules/layers-slices/model/validate-and-report.ts
+++ b/src/rules/layers-slices/model/validate-and-report.ts
@@ -72,6 +72,7 @@ export function validateAndReport(
   context: RuleContext,
   optionsWithDefault: Readonly<Options>,
   config?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
 ) {
   if (!hasPath(node)) {
     return;
@@ -82,7 +83,7 @@ export function validateAndReport(
     return;
   }
 
-  const pathsInfo = extractPathsInfo(node, context, { layersConfig: config });
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig: config, segmentsConfig });
 
   /*
    * Check @x cross-import pattern.

--- a/src/rules/layers-slices/model/validate-and-report.ts
+++ b/src/rules/layers-slices/model/validate-and-report.ts
@@ -82,7 +82,7 @@ export function validateAndReport(
     return;
   }
 
-  const pathsInfo = extractPathsInfo(node, context, config);
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig: config });
 
   /*
    * Check @x cross-import pattern.

--- a/src/rules/public-api/config.ts
+++ b/src/rules/public-api/config.ts
@@ -4,6 +4,7 @@ export const MESSAGE_ID = {
   SHOULD_BE_FROM_PUBLIC_API: 'should-be-from-public-api',
   REMOVE_SUGGESTION: 'remove-suggestion',
   LAYERS_PUBLIC_API_NOT_ALLOWED: 'layers-public-api-not-allowed',
+  UNKNOWN_SEGMENT: 'unknown-segment',
 } as const;
 
 export const VALIDATION_LEVEL = {

--- a/src/rules/public-api/index.custom-segments.test.ts
+++ b/src/rules/public-api/index.custom-segments.test.ts
@@ -1,0 +1,206 @@
+import * as tseslintParser from '@typescript-eslint/parser';
+import { RuleTester } from '../../../tests/rule-tester';
+import {
+  makeCustomSegmentsSettings,
+  makePublicApiErrorWithSuggestion,
+  makePublicApiOptions,
+  makeUnknownSegmentError,
+} from '../../../tests/utils';
+import { VALIDATION_LEVEL } from './config';
+import rule from './index';
+
+/**
+ * Custom segments configuration for testing (extend mode).
+ * Adds 'services' and 'hooks' to default segments.
+ */
+const customSegmentsExtend = ['services', 'hooks'];
+const extendSegmentsSettings = makeCustomSegmentsSettings(customSegmentsExtend);
+
+/**
+ * Custom segments configuration for testing (replace mode).
+ * Only allows 'ui', 'model', and 'services'.
+ */
+const customSegmentsReplace = { replace: ['ui', 'model', 'services'] };
+const replaceSegmentsSettings = makeCustomSegmentsSettings(customSegmentsReplace);
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+    parser: tseslintParser,
+  },
+});
+
+ruleTester.run('public-api (custom segments - extend mode)', rule, {
+  valid: [
+    {
+      name: 'should allow import from default segment (ui)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { Button } from '@/entities/user'",
+      settings: extendSegmentsSettings,
+    },
+    {
+      name: 'should allow import from custom segment (services) via public API',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { userService } from '@/entities/user'",
+      settings: extendSegmentsSettings,
+    },
+    {
+      name: 'should allow import from slice public API when using custom segments',
+      filename: 'src/pages/home/ui.tsx',
+      code: "import { AuthForm } from '@/features/auth'",
+      settings: extendSegmentsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on deep import from default segment',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { UserModel } from '@/entities/user/model'",
+      settings: extendSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'model',
+          "import { UserModel } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+    {
+      name: 'should error on deep import from custom segment (services)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user/services'",
+      settings: extendSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'services',
+          "import { api } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+    {
+      name: 'should error on deep import from custom segment (hooks)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { useUser } from '@/entities/user/hooks'",
+      settings: extendSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'hooks',
+          "import { useUser } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+    {
+      name: 'should error on deep import from nested custom segment path',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { useAuth } from '@/entities/user/hooks/useAuth'",
+      settings: extendSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'hooks/useAuth',
+          "import { useAuth } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+  ],
+});
+
+ruleTester.run('public-api (custom segments - replace mode)', rule, {
+  valid: [
+    {
+      name: 'should allow import from included segment (ui)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { Button } from '@/entities/user'",
+      settings: replaceSegmentsSettings,
+    },
+    {
+      name: 'should allow import from included segment (services)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user'",
+      settings: replaceSegmentsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on deep import from included segment',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { UserModel } from '@/entities/user/model'",
+      settings: replaceSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'model',
+          "import { UserModel } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+    {
+      name: 'should error on deep import from custom segment (services)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user/services'",
+      settings: replaceSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'services',
+          "import { api } from '@/entities/user'",
+          '@/entities/user',
+        ),
+      ],
+    },
+  ],
+});
+
+ruleTester.run('public-api (unknown segment detection)', rule, {
+  valid: [
+    {
+      name: 'should not error for import from public API (no segment)',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { Button } from '@/entities/user'",
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+    },
+    {
+      name: 'should not error for import from public API with custom segments',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user'",
+      settings: extendSegmentsSettings,
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on unknown segment with default config',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user/unknown'",
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+      errors: [
+        makeUnknownSegmentError('unknown'),
+      ],
+    },
+    {
+      name: 'should error on unknown segment with extend config',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { something } from '@/entities/user/stores'",
+      settings: extendSegmentsSettings,
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+      errors: [
+        makeUnknownSegmentError('stores'),
+      ],
+    },
+    {
+      name: 'should error on segment not in replace list',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/user/lib'",
+      settings: replaceSegmentsSettings,
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+      errors: [
+        makeUnknownSegmentError('lib'),
+      ],
+    },
+  ],
+});

--- a/src/rules/public-api/index.custom-segments.test.ts
+++ b/src/rules/public-api/index.custom-segments.test.ts
@@ -1,6 +1,7 @@
 import * as tseslintParser from '@typescript-eslint/parser';
 import { RuleTester } from '../../../tests/rule-tester';
 import {
+  makeCustomLayersAndSegmentsSettings,
   makeCustomSegmentsSettings,
   makePublicApiErrorWithSuggestion,
   makePublicApiOptions,
@@ -200,6 +201,77 @@ ruleTester.run('public-api (unknown segment detection)', rule, {
       options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
       errors: [
         makeUnknownSegmentError('lib'),
+      ],
+    },
+  ],
+});
+
+/**
+ * Custom layers + custom segments combined configuration
+ */
+const customLayersAndSegmentsSettings = makeCustomLayersAndSegmentsSettings(
+  [
+    { name: 'shared', hasSlices: false },
+    'domain',
+    'features',
+    { name: 'app', hasSlices: false },
+  ],
+  ['services', 'hooks'],
+);
+
+ruleTester.run('public-api (custom layers + custom segments)', rule, {
+  valid: [
+    {
+      name: 'should allow import from public API with custom layers and segments',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { User } from '@/domain/user'",
+      settings: customLayersAndSegmentsSettings,
+    },
+    {
+      name: 'should recognize custom segment with custom layers',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { domainService } from '@/domain/user'",
+      settings: customLayersAndSegmentsSettings,
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on deep import with custom layers and segments',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/domain/user/services'",
+      settings: customLayersAndSegmentsSettings,
+      errors: [
+        makePublicApiErrorWithSuggestion(
+          'services',
+          "import { api } from '@/domain/user'",
+          '@/domain/user',
+        ),
+      ],
+    },
+  ],
+});
+
+ruleTester.run('public-api (group folders with unknown segment)', rule, {
+  valid: [
+    {
+      name: 'should not error for known segment in group folder path',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/(users)/admin/model'",
+      settings: extendSegmentsSettings,
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'should error on unknown segment in group folder path',
+      filename: 'src/features/auth/ui.tsx',
+      code: "import { api } from '@/entities/(users)/admin/unknown'",
+      settings: extendSegmentsSettings,
+      options: makePublicApiOptions({ level: VALIDATION_LEVEL.SEGMENTS }),
+      errors: [
+        makeUnknownSegmentError('unknown'),
       ],
     },
   ],

--- a/src/rules/public-api/index.ts
+++ b/src/rules/public-api/index.ts
@@ -25,7 +25,7 @@ export default createEslintRule<Options, MessageIds>({
       [MESSAGE_ID.SHOULD_BE_FROM_PUBLIC_API]: 'Absolute imports are only allowed from public api ("{{ fixedPath }}")',
       [MESSAGE_ID.REMOVE_SUGGESTION]: 'Remove the "{{ valueToRemove }}"',
       [MESSAGE_ID.LAYERS_PUBLIC_API_NOT_ALLOWED]: 'The layer public API is not allowed. It harms both architecturally and practically (code splitting)',
-      [MESSAGE_ID.UNKNOWN_SEGMENT]: 'Unknown segment "{{ segment }}". Configure in settings or use public API.',
+      [MESSAGE_ID.UNKNOWN_SEGMENT]: 'Unknown segment "{{ segment }}". Add it to segments configuration or use the public API.',
     },
     schema: [
       {

--- a/src/rules/public-api/index.ts
+++ b/src/rules/public-api/index.ts
@@ -1,6 +1,7 @@
 import {
   createEslintRule,
   extractLayersConfig,
+  extractSegmentsConfig,
   type ImportExpression,
 } from '../../lib/rule';
 import {
@@ -24,6 +25,7 @@ export default createEslintRule<Options, MessageIds>({
       [MESSAGE_ID.SHOULD_BE_FROM_PUBLIC_API]: 'Absolute imports are only allowed from public api ("{{ fixedPath }}")',
       [MESSAGE_ID.REMOVE_SUGGESTION]: 'Remove the "{{ valueToRemove }}"',
       [MESSAGE_ID.LAYERS_PUBLIC_API_NOT_ALLOWED]: 'The layer public API is not allowed. It harms both architecturally and practically (code splitting)',
+      [MESSAGE_ID.UNKNOWN_SEGMENT]: 'Unknown segment "{{ segment }}". Configure in settings or use public API.',
     },
     schema: [
       {
@@ -62,19 +64,20 @@ export default createEslintRule<Options, MessageIds>({
 
   create(context, optionsWithDefault) {
     const layersConfig = extractLayersConfig(context);
+    const segmentsConfig = extractSegmentsConfig(context);
 
     return {
       ImportDeclaration(node) {
-        validateAndReport(node, context, optionsWithDefault, layersConfig);
+        validateAndReport(node, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
       ImportExpression(node) {
-        validateAndReport(node as ImportExpression /* TSESTree has invalid type for this node */, context, optionsWithDefault, layersConfig);
+        validateAndReport(node as ImportExpression /* TSESTree has invalid type for this node */, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
       ExportAllDeclaration(node) {
-        validateAndReport(node, context, optionsWithDefault, layersConfig);
+        validateAndReport(node, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
       ExportNamedDeclaration(node) {
-        validateAndReport(node, context, optionsWithDefault, layersConfig);
+        validateAndReport(node, context, optionsWithDefault, layersConfig, segmentsConfig);
       },
       Program(node) {
         validateAndReportProgram(node, context, optionsWithDefault);

--- a/src/rules/public-api/model/errors.ts
+++ b/src/rules/public-api/model/errors.ts
@@ -15,8 +15,9 @@ export function reportShouldBeFromPublicApi(
   node: ImportExportNodesWithSourceValue,
   context: RuleContext,
   layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
 ) {
-  const pathsInfo = extractPathsInfo(node, context, { layersConfig });
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig, segmentsConfig });
   const [fixedPath, valueToRemove] = convertToPublicApi(pathsInfo);
 
   context.report({
@@ -34,6 +35,20 @@ export function reportShouldBeFromPublicApi(
         fix: (fixer) => fixer.replaceTextRange(getSourceRangeWithoutQuotes(node.source.range), fixedPath),
       },
     ],
+  });
+}
+
+export function reportUnknownSegment(
+  node: ImportExportNodesWithSourceValue,
+  context: RuleContext,
+  segment: string,
+) {
+  context.report({
+    node: node.source,
+    messageId: MESSAGE_ID.UNKNOWN_SEGMENT,
+    data: {
+      segment,
+    },
   });
 }
 

--- a/src/rules/public-api/model/errors.ts
+++ b/src/rules/public-api/model/errors.ts
@@ -16,7 +16,7 @@ export function reportShouldBeFromPublicApi(
   context: RuleContext,
   layersConfig?: NormalizedLayerConfig[],
 ) {
-  const pathsInfo = extractPathsInfo(node, context, layersConfig);
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig });
   const [fixedPath, valueToRemove] = convertToPublicApi(pathsInfo);
 
   context.report({

--- a/src/rules/public-api/model/is-unknown-segment.ts
+++ b/src/rules/public-api/model/is-unknown-segment.ts
@@ -14,8 +14,16 @@ import {
 } from '../config';
 
 /**
+ * Checks if a path part is a group folder (e.g., "(auth-group)")
+ */
+function isGroupFolder(part: string): boolean {
+  return part.startsWith('(') && part.endsWith(')');
+}
+
+/**
  * Extracts potential segment from path after slice.
  * Returns the segment name if found in path structure, null otherwise.
+ * Handles group folders by skipping them.
  */
 function extractPotentialSegment(
   targetPath: string,
@@ -34,17 +42,18 @@ function extractPotentialSegment(
     return null;
   }
 
-  /* Structure: layer/slice/segment or layer/group/slice/segment */
+  /* Structure: layer/slice/segment or layer/(group)/slice/segment */
   const partsAfterLayer = parts.slice(layerIndex + 1);
 
-  if (partsAfterLayer.length < 2) {
+  /* Filter out group folders to get actual slice/segment structure */
+  const nonGroupParts = partsAfterLayer.filter((part) => !isGroupFolder(part));
+
+  if (nonGroupParts.length < 2) {
     return null;
   }
 
-  /* Find the second segment after layer (could be slice or group) */
-  /* Then check the third one which should be segment */
-  /* For simplicity, check if 2nd part looks like a segment */
-  const potentialSegment = partsAfterLayer[1];
+  /* After filtering groups: [slice, segment, ...] */
+  const potentialSegment = nonGroupParts[1];
 
   /* Remove file extension if present */
   const segmentWithoutExt = potentialSegment?.replace(/\.\w+$/, '') || null;

--- a/src/rules/public-api/model/is-unknown-segment.ts
+++ b/src/rules/public-api/model/is-unknown-segment.ts
@@ -1,0 +1,96 @@
+import type { NormalizedLayerConfig } from '../../../config';
+import { DEFAULT_SEGMENTS } from '../../../config';
+import { extractPathsInfo } from '../../../lib/feature-sliced';
+import { getLayersWithSlices, normalizeLayersConfig } from '../../../lib/feature-sliced/layers-config';
+import { isKnownSegment } from '../../../lib/feature-sliced/segments-config';
+import {
+  extractRuleOptions,
+  type ImportExportNodesWithSourceValue,
+} from '../../../lib/rule';
+import {
+  type Options,
+  type RuleContext,
+  VALIDATION_LEVEL,
+} from '../config';
+
+/**
+ * Extracts potential segment from path after slice.
+ * Returns the segment name if found in path structure, null otherwise.
+ */
+function extractPotentialSegment(
+  targetPath: string,
+  layersConfig?: NormalizedLayerConfig[],
+): string | null {
+  const normalizedLayersConfig = layersConfig ?? normalizeLayersConfig();
+  const layersWithSlices = getLayersWithSlices(normalizedLayersConfig);
+
+  const parts = targetPath.split('/').filter(Boolean);
+
+  const layerIndex = parts.findIndex((part) =>
+    layersWithSlices.some((layer) => layer.toLowerCase() === part.toLowerCase()),
+  );
+
+  if (layerIndex === -1 || layerIndex >= parts.length - 2) {
+    return null;
+  }
+
+  /* Structure: layer/slice/segment or layer/group/slice/segment */
+  const partsAfterLayer = parts.slice(layerIndex + 1);
+
+  if (partsAfterLayer.length < 2) {
+    return null;
+  }
+
+  /* Find the second segment after layer (could be slice or group) */
+  /* Then check the third one which should be segment */
+  /* For simplicity, check if 2nd part looks like a segment */
+  const potentialSegment = partsAfterLayer[1];
+
+  /* Remove file extension if present */
+  const segmentWithoutExt = potentialSegment?.replace(/\.\w+$/, '') || null;
+
+  return segmentWithoutExt;
+}
+
+/**
+ * Checks if the import path contains an unknown segment.
+ * Returns the unknown segment name if found, null otherwise.
+ *
+ * Only checks at SEGMENTS validation level.
+ */
+export function isUnknownSegment(
+  node: ImportExportNodesWithSourceValue,
+  context: RuleContext,
+  optionsWithDefault: Readonly<Options>,
+  layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
+): string | null {
+  const ruleOptions = extractRuleOptions(optionsWithDefault);
+
+  if (ruleOptions.level !== VALIDATION_LEVEL.SEGMENTS) {
+    return null;
+  }
+
+  const effectiveSegmentsConfig = segmentsConfig ?? [...DEFAULT_SEGMENTS];
+
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig, segmentsConfig: effectiveSegmentsConfig });
+
+  /* If segment was already extracted successfully, it's known */
+  if (pathsInfo.fsdPartsOfTarget.segment) {
+    return null;
+  }
+
+  /* Try to extract potential segment from path */
+  const potentialSegment = extractPotentialSegment(pathsInfo.normalizedTargetPath, layersConfig);
+
+  if (!potentialSegment) {
+    return null;
+  }
+
+  /* Check if it looks like a segment but isn't known */
+  if (!isKnownSegment(potentialSegment, effectiveSegmentsConfig)) {
+    return potentialSegment;
+  }
+
+  return null;
+}

--- a/src/rules/public-api/model/should-be-from-public-api.ts
+++ b/src/rules/public-api/model/should-be-from-public-api.ts
@@ -54,7 +54,7 @@ export function shouldBeFromPublicApi(
   optionsWithDefault: Readonly<Options>,
   layersConfig?: NormalizedLayerConfig[],
 ): boolean {
-  const pathsInfo = extractPathsInfo(node, context, layersConfig);
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig });
   const ruleOptions = extractRuleOptions(optionsWithDefault);
 
   /*

--- a/src/rules/public-api/model/should-be-from-public-api.ts
+++ b/src/rules/public-api/model/should-be-from-public-api.ts
@@ -53,8 +53,9 @@ export function shouldBeFromPublicApi(
   context: RuleContext,
   optionsWithDefault: Readonly<Options>,
   layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
 ): boolean {
-  const pathsInfo = extractPathsInfo(node, context, { layersConfig });
+  const pathsInfo = extractPathsInfo(node, context, { layersConfig, segmentsConfig });
   const ruleOptions = extractRuleOptions(optionsWithDefault);
 
   /*

--- a/src/rules/public-api/model/validate-and-report.ts
+++ b/src/rules/public-api/model/validate-and-report.ts
@@ -9,7 +9,8 @@ import {
   isIgnoredCurrentFile,
   isIgnoredTarget,
 } from '../../../lib/rule';
-import { reportShouldBeFromPublicApi } from './errors';
+import { reportShouldBeFromPublicApi, reportUnknownSegment } from './errors';
+import { isUnknownSegment } from './is-unknown-segment';
 import { shouldBeFromPublicApi } from './should-be-from-public-api';
 
 export function validateAndReport(
@@ -17,6 +18,7 @@ export function validateAndReport(
   context: RuleContext,
   optionsWithDefault: Readonly<Options>,
   layersConfig?: NormalizedLayerConfig[],
+  segmentsConfig?: string[],
 ) {
   if (!hasPath(node)) {
     return;
@@ -27,7 +29,13 @@ export function validateAndReport(
     return;
   }
 
-  if (shouldBeFromPublicApi(node, context, optionsWithDefault, layersConfig)) {
-    reportShouldBeFromPublicApi(node, context, layersConfig);
+  const unknownSegment = isUnknownSegment(node, context, optionsWithDefault, layersConfig, segmentsConfig);
+  if (unknownSegment) {
+    reportUnknownSegment(node, context, unknownSegment);
+    return;
+  }
+
+  if (shouldBeFromPublicApi(node, context, optionsWithDefault, layersConfig, segmentsConfig)) {
+    reportShouldBeFromPublicApi(node, context, layersConfig, segmentsConfig);
   }
 }

--- a/tests/utils/test-helpers.ts
+++ b/tests/utils/test-helpers.ts
@@ -1,5 +1,5 @@
 import type { TSESLint } from '@typescript-eslint/utils';
-import type { Layer, LayersConfig, NormalizedLayerConfig } from '../../src/config';
+import type { Layer, LayersConfig, NormalizedLayerConfig, SegmentsConfig } from '../../src/config';
 import { PLUGIN_NAME } from '../../src/config';
 import { normalizeLayersConfig } from '../../src/lib/feature-sliced/layers-config';
 import {
@@ -13,6 +13,7 @@ import {
 } from '../../src/rules/layers-slices/config';
 import {
   MESSAGE_ID as PUBLIC_API_MESSAGE_ID,
+  type MessageIds as PublicApiMessageIds,
   type Options as PublicApiOptions,
   VALIDATION_LEVEL,
   type ValidationLevel,
@@ -260,6 +261,48 @@ export function makeCustomLayersSlicesError(
       importLayer,
       currentFileLayer,
       layersOrder,
+    },
+  };
+}
+
+/* === Custom segments helpers === */
+
+/**
+ * Creates ESLint settings with custom segments configuration
+ */
+export function makeCustomSegmentsSettings(segments: SegmentsConfig): Record<string, unknown> {
+  return {
+    [PLUGIN_NAME]: {
+      segments,
+    },
+  };
+}
+
+/**
+ * Creates ESLint settings with both custom layers and custom segments
+ */
+export function makeCustomLayersAndSegmentsSettings(
+  layers: LayersConfig,
+  segments: SegmentsConfig,
+): Record<string, unknown> {
+  return {
+    [PLUGIN_NAME]: {
+      layers: normalizeLayersConfig(layers),
+      segments,
+    },
+  };
+}
+
+/**
+ * Creates error for unknown segment
+ */
+export function makeUnknownSegmentError(
+  segment: string,
+): TSESLint.TestCaseError<PublicApiMessageIds> {
+  return {
+    messageId: PUBLIC_API_MESSAGE_ID.UNKNOWN_SEGMENT,
+    data: {
+      segment,
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds configurable custom segments support to eslint-plugin-feature-sliced, allowing users to extend or replace the default segment list.

### Features
- **Extend mode** (default): adds custom segments to defaults (ui, model, lib, api, config, assets)
- **Replace mode**: completely replaces the default segment list
- **Unknown segment detection**: errors on SEGMENTS validation level in `public-api` rule

### Configuration API

```js
// eslint.config.js
featureSliced({
  // Extend mode - adds to defaults
  segments: ['services', 'hooks'],

  // Replace mode - replaces defaults
  segments: { replace: ['ui', 'model', 'services'] },
})
```

### Changes
- Added `segments-config` utilities for normalizing and validating segments
- Added `extract-segments-config` to read config from ESLint settings
- Updated `extractSegment` and `extractSlice` to accept custom config
- Updated `public-api` rule with unknown segment error (SEGMENTS level)
- Updated `layers-slices` rule to pass segments config

### Test plan
- [x] All 455 tests pass
- [x] Type-check passes
- [x] Lint passes
- [x] Manual testing with example project

Closes #22